### PR TITLE
Update bgboard.js

### DIFF
--- a/js/bgboard.js
+++ b/js/bgboard.js
@@ -622,6 +622,7 @@ BgBoard.prototype.drawBoard = function () {
 	for (var i = 0; i < trs.length; i++) {
 
 		var tr = trs[i];
+		tr.replaceChildren();
 
 		var td1 = document.createElement('td');
 		if (i == 0) {


### PR DESCRIPTION
Fix for adding cells to info board on redraw board. It was appending new td's to tr's without clearing first.